### PR TITLE
Replace hard-coded localhost comment with documentation link

### DIFF
--- a/WebApplication1/Program.cs
+++ b/WebApplication1/Program.cs
@@ -26,4 +26,5 @@ app.UseAuthorization();
 app.MapRazorPages();
 app.Run();
 
-/// http://localhost:5078/
+// For configuring the app's URLs, see https://learn.microsoft.com/aspnet/core/fundamentals/servers/kestrel/endpoints
+


### PR DESCRIPTION
## Summary
- replace the hard-coded localhost comment in Program.cs with a link to official documentation about configuring endpoints
- ensure the comment no longer suggests a fixed address

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_6905d1646e388323b7624c3110410ddf