### PR TITLE
Display suppliers in the admin WPF app

### DIFF
--- a/AdminAppWpf/AdminAppWpf.csproj
+++ b/AdminAppWpf/AdminAppWpf.csproj
@@ -94,5 +94,17 @@
   <ItemGroup>
     <None Include="App.config" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DDMLib\DDMLib.csproj">
+      <Project>{DABB27A7-390A-4A79-A713-88C990A717C5}</Project>
+      <Name>DDMLib</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\DDMLib\config.ini">
+      <Link>config.ini</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/AdminAppWpf/MainWindow.xaml
+++ b/AdminAppWpf/MainWindow.xaml
@@ -1,12 +1,38 @@
-﻿<Window x:Class="AdminAppWpf.MainWindow"
+<Window x:Class="AdminAppWpf.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:AdminAppWpf"
         mc:Ignorable="d"
-        Title="MainWindow" Height="450" Width="800">
-    <Grid>
-        
+        Title="Управление поставщиками" Height="450" Width="800">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <Button x:Name="ShowSuppliersButton"
+                Content="Показать поставщиков"
+                Width="200"
+                Height="35"
+                HorizontalAlignment="Left"
+                Click="ShowSuppliersButton_Click" />
+
+        <DataGrid x:Name="SuppliersDataGrid"
+                  Grid.Row="1"
+                  Margin="0,10,0,0"
+                  AutoGenerateColumns="False"
+                  IsReadOnly="True"
+                  CanUserAddRows="False"
+                  CanUserDeleteRows="False">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="ИНН" Binding="{Binding Inn}" Width="100" />
+                <DataGridTextColumn Header="Название" Binding="{Binding Name}" Width="200" />
+                <DataGridTextColumn Header="E-mail" Binding="{Binding ContactEmail}" Width="200" />
+                <DataGridTextColumn Header="Телефон" Binding="{Binding Phone}" Width="120" />
+                <DataGridTextColumn Header="Адрес" Binding="{Binding Address}" Width="*" />
+            </DataGrid.Columns>
+        </DataGrid>
     </Grid>
 </Window>

--- a/AdminAppWpf/MainWindow.xaml.cs
+++ b/AdminAppWpf/MainWindow.xaml.cs
@@ -1,17 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System;
+using System.Collections.ObjectModel;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+using DDMLib;
 
 namespace AdminAppWpf
 {
@@ -20,9 +10,32 @@ namespace AdminAppWpf
     /// </summary>
     public partial class MainWindow : Window
     {
+        private readonly SupplierService supplierService_;
+        private readonly ObservableCollection<Supplier> suppliers_ = new ObservableCollection<Supplier>();
+
         public MainWindow()
         {
             InitializeComponent();
+            supplierService_ = new SupplierService(new MySqlSupplierRepository());
+            SuppliersDataGrid.ItemsSource = suppliers_;
+        }
+
+        private void ShowSuppliersButton_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                suppliers_.Clear();
+                var suppliers = supplierService_.GetAllSuppliers();
+
+                foreach (var supplier in suppliers)
+                {
+                    suppliers_.Add(supplier);
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Ошибка при загрузке списка поставщиков: {ex.Message}", "Ошибка", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
         }
     }
 }

--- a/DDMLib/Supplier/MySqlSupplierRepository.cs
+++ b/DDMLib/Supplier/MySqlSupplierRepository.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using MySql.Data.MySqlClient;
 
 namespace DDMLib
 {
@@ -10,7 +8,50 @@ namespace DDMLib
     {
         public List<Supplier> ReadAllSuppliers()
         {
-            throw new NotImplementedException();
+            var suppliers = new List<Supplier>();
+
+            if (!Config.TestDatabaseConnection())
+            {
+                ErrorLogger.LogError(nameof(ReadAllSuppliers), "Не удалось подключиться к базе данных.");
+            }
+
+            using (var connection = new MySqlConnection(Config.ConnectionString))
+            {
+                try
+                {
+                    connection.Open();
+
+                    var command = new MySqlCommand(@"SELECT inn, name, contact_email, phone, address FROM suppliers ORDER BY name;", connection);
+
+                    using (var reader = command.ExecuteReader())
+                    {
+                        int iInn = reader.GetOrdinal("inn");
+                        int iName = reader.GetOrdinal("name");
+                        int iEmail = reader.GetOrdinal("contact_email");
+                        int iPhone = reader.GetOrdinal("phone");
+                        int iAddress = reader.GetOrdinal("address");
+
+                        while (reader.Read())
+                        {
+                            suppliers.Add(new Supplier
+                            {
+                                Inn = reader.IsDBNull(iInn) ? 0 : reader.GetInt32(iInn),
+                                Name = reader.IsDBNull(iName) ? string.Empty : reader.GetString(iName),
+                                ContactEmail = reader.IsDBNull(iEmail) ? string.Empty : reader.GetString(iEmail),
+                                Phone = reader.IsDBNull(iPhone) ? null : reader.GetString(iPhone),
+                                Address = reader.IsDBNull(iAddress) ? null : reader.GetString(iAddress)
+                            });
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    ErrorLogger.LogError(nameof(ReadAllSuppliers), ex.Message);
+                    throw;
+                }
+            }
+
+            return suppliers;
         }
     }
 }

--- a/DDMLib/Supplier/Supplier.cs
+++ b/DDMLib/Supplier/Supplier.cs
@@ -8,7 +8,7 @@ namespace DDMLib
 {
     public class Supplier
     {
-        public int Inn { get; }
+        public int Inn { get; set; }
         public string Name { get; set; }
         public string ContactEmail { get; set; }
         public string Phone { get; set; }  // может быть null


### PR DESCRIPTION
## Summary
- implement supplier retrieval in DDMLib via MySqlSupplierRepository
- add supplier table UI and loading logic to the admin WPF application
- link the WPF project to DDMLib and ensure the database configuration is copied to the output directory

## Testing
- `dotnet test mainSolution.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6905d320d9948323b41449f38b276e50